### PR TITLE
fix: support non-UTF8 filenames in PF8 archives using lossy decoding

### DIFF
--- a/pf8/src/format.rs
+++ b/pf8/src/format.rs
@@ -110,7 +110,7 @@ pub fn parse_entries(data: &[u8]) -> Result<(Vec<RawEntry>, ArchiveFormat)> {
         }
 
         let name_bytes = &data[cursor..cursor + name_length as usize];
-        let name = String::from_utf8(name_bytes.to_vec())?;
+        let name = String::from_utf8_lossy(name_bytes).into_owned();
         cursor += name_length as usize + 4; // Skip name and 4 zero bytes
 
         let offset = read_u32_le(data, cursor)?;


### PR DESCRIPTION
## Problem
The `pf8` library currently uses strict `String::from_utf8` decoding when reading filenames from the PF8 archive index. This causes the parser to fail with an `Invalid UTF-8` error when encountering archives created with other encodings, such as Shift-JIS (common in Japanese/Chinese games using the Artemis engine).

## Solution
This PR replaces strict UTF-8 decoding with `String::from_utf8_lossy(...).into_owned()`.
- This ensures that the parsing process is not interrupted even when filenames contain bytes that are invalid in UTF-8.
- It provides better compatibility with archives from different regions and legacy systems.
- The change is minimal and does not affect the core file format parsing logic.

## Verification
- Verified by building the project and running the `pfs-rs` tool on an archive containing Shift-JIS filenames (`root.pfs.098 -  https://pixeldrain.com/u/oXFqycMm`).
- The tool now successfully lists and extracts all files without any UTF-8 errors.